### PR TITLE
Merge staging into main branch

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -27,13 +27,15 @@ function MyApp ({
 
   return (
     <SeoLayout canonical={canonical}>
-      {pageProps?.pageScripts ? (
-        <Script
-          id='bloom-widget'
-          strategy='afterInteractive'
-          dangerouslySetInnerHTML={{ __html: pageProps.pageScripts }}
-        />
-      ) : null}
+      {pageProps?.pageScripts
+        ? (
+          <Script
+            id='bloom-widget'
+            strategy='afterInteractive'
+            dangerouslySetInnerHTML={{ __html: pageProps.pageScripts }}
+          />
+          )
+        : null}
       <div data-scroll-container className='scroll-container'>
         <Component {...pageProps} />
       </div>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import Script from 'next/script'
 import SeoLayout from '../components/Seo'
 import useLocomotiveScroll from '../hooks/useLocomotiveScroll'
 import '../styles/globals.css'
@@ -17,7 +18,6 @@ function MyApp ({
     ignore: !!query.slug || isMobile || breakpoint
   })
 
-  // hide reservation widget if is 'carta' path
   const isCartaPath = asPath.startsWith('/carta')
 
   useEffect(() => {
@@ -27,6 +27,13 @@ function MyApp ({
 
   return (
     <SeoLayout canonical={canonical}>
+      {pageProps?.pageScripts ? (
+        <Script
+          id='bloom-widget'
+          strategy='afterInteractive'
+          dangerouslySetInnerHTML={{ __html: pageProps.pageScripts }}
+        />
+      ) : null}
       <div data-scroll-container className='scroll-container'>
         <Component {...pageProps} />
       </div>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -8,18 +8,6 @@ export default function Document () {
         <link rel='preconnect' href='https://fonts.googleapis.com' />
         <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='anonymous' />
         <link href='https://fonts.googleapis.com/css2?family=Abel&family=Marcellus&display=swap' rel='stylesheet' />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-(function(w,d,s,o,f,js,fjs){
-  w['JS-Widget']=o;w[o]=w[o]||function(){(w[o].q=w[o].q||[]).push(arguments)};
-  js=d.createElement(s);fjs=d.getElementsByTagName(s)[0];
-  js.id=o;js.src=f;js.async=1;fjs.parentNode.insertBefore(js,fjs);
-})(window,document,'script','mw','https://widget.meitre.com/widget.js?v='+Date.now());
-mw('init',{restaurant_widget_id:'bbd9139b86fd4b2a14ac56a6bf9656d1'});
-            `.trim()
-          }}
-        />
       </Head>
       <body className='relative'>
         <Main />

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -3,15 +3,14 @@ export default async function handler (req, res) {
 
   if (req.headers['x-secret'] === process.env.REVALIDATE_SECRET) {
     if (route === process.env.ROUTE || req.headers['x-secret-route'] === process.env.ROUTE) {
-
       await Promise.all([
         res.revalidate('/carta/nikkei'),
         res.revalidate('/carta/drinks'),
         res.revalidate('/'),
         res.revalidate('/contacto'),
         res.revalidate('/ubicacion'),
-        // await res.revalidate('/rewards')
         res.revalidate('/404')
+        // await res.revalidate('/rewards')
       ])
 
       return res.json({ revalidated: true })

--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -3,13 +3,16 @@ export default async function handler (req, res) {
 
   if (req.headers['x-secret'] === process.env.REVALIDATE_SECRET) {
     if (route === process.env.ROUTE || req.headers['x-secret-route'] === process.env.ROUTE) {
-      await res.revalidate('/carta/nikkei')
-      await res.revalidate('/carta/drinks')
-      await res.revalidate('/')
-      await res.revalidate('/contacto')
-      await res.revalidate('/ubicacion')
-      // await res.revalidate('/rewards')
-      await res.revalidate('/404')
+
+      await Promise.all([
+        res.revalidate('/carta/nikkei'),
+        res.revalidate('/carta/drinks'),
+        res.revalidate('/'),
+        res.revalidate('/contacto'),
+        res.revalidate('/ubicacion'),
+        // await res.revalidate('/rewards')
+        res.revalidate('/404')
+      ])
 
       return res.json({ revalidated: true })
     } else {

--- a/pages/contacto.js
+++ b/pages/contacto.js
@@ -31,7 +31,7 @@ export default ContactPage
 export async function getStaticProps ({ preview = false }) {
   const contactPosts = await cmsApi({ contentType: 'contactPage', slug: 'contact' })
 
-  const { reservationWidgetScript: pageScripts } = contactPosts || {}
+  const { reservationWidgetScript: pageScripts = '' } = contactPosts || {}
 
   return {
     props: { preview, contactPosts, pageScripts }

--- a/pages/contacto.js
+++ b/pages/contacto.js
@@ -31,7 +31,9 @@ export default ContactPage
 export async function getStaticProps ({ preview = false }) {
   const contactPosts = await cmsApi({ contentType: 'contactPage', slug: 'contact' })
 
+  const { reservationWidgetScript: pageScripts } = contactPosts || {}
+
   return {
-    props: { preview, contactPosts }
+    props: { preview, contactPosts, pageScripts }
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -49,10 +49,13 @@ export default Home
 export async function getStaticProps ({ preview = false }) {
   const homePosts = await cmsApi({ contentType: 'homePage', slug: 'home' })
 
+  const { reservationWidgetScript: pageScripts } = homePosts || {}
+
   return {
     props: {
       preview,
-      homePosts
+      homePosts,
+      pageScripts
     }
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -49,7 +49,7 @@ export default Home
 export async function getStaticProps ({ preview = false }) {
   const homePosts = await cmsApi({ contentType: 'homePage', slug: 'home' })
 
-  const { reservationWidgetScript: pageScripts } = homePosts || {}
+  const { reservationWidgetScript: pageScripts = '' } = homePosts || {}
 
   return {
     props: {

--- a/pages/ubicacion.js
+++ b/pages/ubicacion.js
@@ -39,7 +39,7 @@ export default LocationPage
 export async function getStaticProps ({ preview = false }) {
   const locationPosts = await cmsApi({ contentType: 'locationPage', slug: 'location' })
 
-  const { reservationWidgetScript: pageScripts } = locationPosts || {}
+  const { reservationWidgetScript: pageScripts = '' } = locationPosts || {}
 
   return {
     props: { preview, locationPosts, pageScripts }

--- a/pages/ubicacion.js
+++ b/pages/ubicacion.js
@@ -39,7 +39,9 @@ export default LocationPage
 export async function getStaticProps ({ preview = false }) {
   const locationPosts = await cmsApi({ contentType: 'locationPage', slug: 'location' })
 
+  const { reservationWidgetScript: pageScripts } = locationPosts || {}
+
   return {
-    props: { preview, locationPosts }
+    props: { preview, locationPosts, pageScripts }
   }
 }


### PR DESCRIPTION
This pull request refactors how the reservation widget script is injected into the application, moving it from a global script in `_document.js` to being dynamically injected on a per-page basis using Next.js's `Script` component. Additionally, it optimizes the revalidation API by performing revalidations in parallel and includes the widget script in the page props for relevant pages.

**Dynamic Script Injection Improvements:**
- The reservation widget script is no longer injected globally in `_document.js`. Instead, it is conditionally injected in `_app.js` using the Next.js `Script` component, utilizing the `pageScripts` prop provided by each page. This allows for better control over which pages load the widget script and improves maintainability. [[1]](diffhunk://#diff-c85e043f1db00b919581c615d87508f7d4ff2bb8058798ebbe475b4a6e087f26R2) [[2]](diffhunk://#diff-c85e043f1db00b919581c615d87508f7d4ff2bb8058798ebbe475b4a6e087f26R30-R38) [[3]](diffhunk://#diff-69a97c4e30118f9e9000fedfd8f59f43b4353021528208a4ff946e503c0b3dacL11-L22)

**Page Data Enhancements:**
- The `getStaticProps` functions for `contacto.js`, `index.js`, and `ubicacion.js` now extract the `reservationWidgetScript` from their respective CMS data and pass it as `pageScripts` in the page props, enabling dynamic script injection. [[1]](diffhunk://#diff-9ba748b8fac9b692fe2578f672c338b9bb8fc4604dcdf694c926962dfef34c99R34-R37) [[2]](diffhunk://#diff-7c97c1ad17c63f34774324965f81661cea32f533a65c39ab03576069972e4d0eR52-R58) [[3]](diffhunk://#diff-142d4f8264243d6233ed65a8e4ea752e8665255ef3a698b9a349824ff02fac2eR42-R45)

**API Optimization:**
- The revalidation API endpoint (`pages/api/revalidate.js`) now performs all revalidation tasks in parallel using `Promise.all`, which can improve performance and reliability.