### PR TITLE
Merge staging into main branch

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -48,6 +48,16 @@
   #meitre-widget-root .meitre-widget__launch__button .smaller-button {
     display: none !important;
   }
+  #meitre-widget-root .meitre-widget-dialog .close-button {
+    top: .5% !important;
+    right: .5% !important;
+    color: #E7EBE7 !important;
+    background-color: #FF5900 !important;
+  }
+  #meitre-widget-root .meitre-widget-dialog .close-button:hover {
+    color: #FF5900 !important;
+    background-color: #FFF !important;
+  }
 }
 
 


### PR DESCRIPTION
Introduces new styling for the close button in the Meitre widget dialog. The changes update the button's position, color, and background, as well as its appearance on hover.

Meitre widget dialog close button styling:

* Added CSS rules to `.close-button` within `.meitre-widget-dialog` to set its position (`top` and `right`), text color, and background color.
* Added hover state styling for `.close-button` to invert the text and background colors when hovered.